### PR TITLE
str_type() wasn't checking for ansi escape codes

### DIFF
--- a/src/notify.c
+++ b/src/notify.c
@@ -268,7 +268,7 @@ str_type(const char *str)
   type &= ~(MSG_PUEBLO | MSG_STRIPACCENTS);
 #endif                          /* CHECK_FOR_HTML */
 
-  if (strstr(str, MARKUP_START "c") == NULL) {
+  if (strstr(str, MARKUP_START "c") == NULL && strchr(str, ESC_CHAR) == NULL) {
     /* No ANSI */
     type &= ~(MSG_ANSI2 | MSG_ANSI16 | MSG_XTERM256);
   }


### PR DESCRIPTION
Fixes issue #1050.

str_type() checked for new markup, but did not check for old ansi escape codes (ESC_CHAR) before setting the string type as non ansi.