### PR TITLE
Strip markup from fetch_ufin_attrib()

### DIFF
--- a/CHANGES.186
+++ b/CHANGES.186
@@ -15,6 +15,7 @@ Numbers next to the developer credit refer to Github issue numbers.
 Version 1.8.6 patchlevel 2                                 ??? ??, 20??
 
 Fixes:
+ * Remove markup from fetch_ufun_attrib() Reported by several people. PR by Qon.
  * Fix compilation errors with OpenSSL 1.1. [SW]
  * Fix overflow bug in mapsql(). [MG]
  * elements() would very rarely give an extra delimiter. Reported by Ashen-Shugar. [1108-MG]

--- a/src/utils.c
+++ b/src/utils.c
@@ -107,6 +107,7 @@ fetch_ufun_attrib(const char *attrstring, dbref executor, ufun_attrib *ufun,
   char *thingname, *attrname;
   char astring[BUFFER_LEN];
   ATTR *attrib;
+  char *stripped = remove_markup(attrstring, NULL);
 
   if (!ufun)
     return 0;
@@ -120,9 +121,9 @@ fetch_ufun_attrib(const char *attrstring, dbref executor, ufun_attrib *ufun,
   ufun->thing = executor;
   thingname = NULL;
 
-  if (!attrstring)
+  if (!stripped)
     return 0;
-  strncpy(astring, attrstring, BUFFER_LEN);
+  strncpy(astring, stripped, BUFFER_LEN);
 
   /* Split obj/attr */
   if ((flags & UFUN_OBJECT) && ((attrname = strchr(astring, '/')) != NULL)) {


### PR DESCRIPTION
Strip markup from passed ufun object/attribute
