### PR TITLE
Strip markup from fetch_ufun_attrib() argument

### DIFF
--- a/CHANGES.187.md
+++ b/CHANGES.187.md
@@ -87,6 +87,7 @@ Fixes
 * A number of issues in the handling UTF-8 text sent by clients have been fixed, as well as improvements in UTF-8 handling in general. [SW]
 * Fix an off-by-one error in command switch initialization code. [SW]
 * `@mail` without a message list respects the current folder instead of using folder 0. [77]
+* ufun(), ulocal(), etc. could get confused by ansi (markup) in the attribute name. Strip markup first. [MT]
 
 Documentation
 -------------

--- a/src/utils.c
+++ b/src/utils.c
@@ -104,10 +104,18 @@ fetch_ufun_attrib(const char *attrstring, dbref executor, ufun_attrib *ufun,
   char *thingname, *attrname;
   char astring[BUFFER_LEN];
   ATTR *attrib;
+  char *stripped;
+
 
   if (!ufun) {
     return 0;
   }
+  
+  if(!attrstring) {
+    return 0;
+  }
+  
+  stripped = remove_markup(attrstring, NULL);
 
   memset(ufun->contents, 0, sizeof ufun->contents);
   ufun->errmess = (char *) "";
@@ -118,11 +126,7 @@ fetch_ufun_attrib(const char *attrstring, dbref executor, ufun_attrib *ufun,
   ufun->thing = executor;
   thingname = NULL;
 
-  if (!attrstring) {
-    return 0;
-  }
-
-  mush_strncpy(astring, attrstring, sizeof astring);
+   mush_strncpy(astring, stripped, sizeof astring);
 
   /* Split obj/attr */
   if ((flags & UFUN_OBJECT) && ((attrname = strchr(astring, '/')) != NULL)) {


### PR DESCRIPTION
Fixes a small but annoying bug when passing an ansified attribute name to ufun(). 
